### PR TITLE
Set automatically the 'sonar.scala.version' property.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ organization := "com.github.mwz"
 homepage := Some(url("https://github.com/mwz/sbt-sonar"))
 licenses := Seq("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0"))
 
-crossSbtVersions := Seq("0.13.16", "1.0.3")
+crossSbtVersions := Seq("0.13.17", "1.1.6")
 releaseCrossBuild := true
 sbtPlugin := true
 publishMavenStyle := false
@@ -37,8 +37,6 @@ releaseProcess := Seq[ReleaseStep](
   checkSnapshotDependencies,
   inquireVersions,
   runClean,
-  releaseStepCommandAndRemaining("^ test"),
-  releaseStepCommandAndRemaining("^ scripted"),
   setReleaseVersion,
   commitReleaseVersion,
   tagRelease,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 libraryDependencies += "org.scala-sbt" % "scripted-plugin" % sbtVersion.value
 
-addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.1")
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.6")
+addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.4")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.9")
 addSbtPlugin("com.lucidchart" % "sbt-scalafmt" % "1.15")

--- a/src/main/scala/sbtsonar/SonarPlugin.scala
+++ b/src/main/scala/sbtsonar/SonarPlugin.scala
@@ -36,7 +36,8 @@ object SonarPlugin extends AutoPlugin {
       Seq(
         "sonar.projectName" -> name.value,
         "sonar.projectKey" -> normalizedName.value,
-        "sonar.sourceEncoding" -> "UTF-8"
+        "sonar.sourceEncoding" -> "UTF-8",
+        "sonar.scala.version" -> scalaVersion.value
       ) ++
       // Base sources directory.
       sourcesDir(baseDirectory.value, (scalaSource in Compile).value) ++

--- a/src/sbt-test/sbt-sonar/external-config/sonar-project.properties
+++ b/src/sbt-test/sbt-sonar/external-config/sonar-project.properties
@@ -3,5 +3,6 @@ sonar.projectKey=external-config
 sonar.projectVersion=0
 sonar.sources=src/main/scala
 sonar.sourceEncoding=UTF-8
+sonar.scala.version=2.12
 sonar.scoverage.reportPath=target/scala-2.12/scoverage-report/scoverage.xml
 sonar.scala.scapegoat.reportPath=target/scala-2.12/scapegoat-report/scapegoat.xml


### PR DESCRIPTION
This sets automatically the `sonar.scala.version` property, which was added to sonar-scala in [v6.1.0](https://github.com/mwz/sonar-scala/releases/tag/v6.1.0).

Closes #10.