### PR TITLE
Use embedded sonar-scanner.

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = "2.0.0-RC4"
+version = "2.0.0-RC7"
 align = some
 align {
   arrowEnumeratorGenerator = false

--- a/build.sbt
+++ b/build.sbt
@@ -33,9 +33,9 @@ scalacOptions ++= Seq(
   "-deprecation"
 )
 libraryDependencies ++= List(
-  "org.sonarsource.scanner.api" % "sonar-scanner-api" % "2.12.0.1661" % Compile,
-  "org.scalatest"               %% "scalatest"        % "3.0.7"       % Test,
-  "org.mockito"                 %% "mockito-scala"    % "1.5.7"       % Test
+  "org.sonarsource.scanner.api" % "sonar-scanner-api"        % "2.12.0.1661" % Compile,
+  "org.scalatest"               %% "scalatest"               % "3.0.7"       % Test,
+  "org.mockito"                 %% "mockito-scala-scalatest" % "1.5.7"       % Test
 )
 scalafmtOnCompile in ThisBuild := true
 cancelable in Global := true

--- a/build.sbt
+++ b/build.sbt
@@ -33,9 +33,9 @@ scalacOptions ++= Seq(
   "-deprecation"
 )
 libraryDependencies ++= List(
-  "org.sonarsource.scanner.api" % "sonar-scanner-api"        % "2.12.0.1661" % Compile,
-  "org.scalatest"               %% "scalatest"               % "3.0.7"       % Test,
-  "org.mockito"                 %% "mockito-scala-scalatest" % "1.5.7"       % Test
+  "org.sonarsource.scanner.api" % "sonar-scanner-api" % "2.12.0.1661" % Compile,
+  "org.scalatest"               %% "scalatest"        % "3.0.7"       % Test,
+  "org.mockito"                 % "mockito-core"      % "2.28.2"      % Test
 )
 scalafmtOnCompile in ThisBuild := true
 cancelable in Global := true

--- a/build.sbt
+++ b/build.sbt
@@ -34,7 +34,8 @@ scalacOptions ++= Seq(
 )
 libraryDependencies ++= List(
   "org.sonarsource.scanner.api" % "sonar-scanner-api" % "2.12.0.1661" % Compile,
-  "org.scalatest"               %% "scalatest"        % "3.0.7"       % Test
+  "org.scalatest"               %% "scalatest"        % "3.0.7"       % Test,
+  "org.mockito"                 %% "mockito-scala"    % "1.5.7"       % Test
 )
 scalafmtOnCompile in ThisBuild := true
 cancelable in Global := true

--- a/build.sbt
+++ b/build.sbt
@@ -1,10 +1,26 @@
+import java.time.Year
+
+import de.heikoseeberger.sbtheader.License
 import ReleaseTransformations._
+
+enablePlugins(AutomateHeaderPlugin)
 enablePlugins(SbtPlugin)
 
 name := "sbt-sonar"
 organization := "com.github.mwz"
 homepage := Some(url("https://github.com/mwz/sbt-sonar"))
+
+// Licence
+organizationName := "All sbt-sonar contributors"
+startYear := Some(2016)
 licenses := Seq("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0"))
+headerLicense := Some(
+  License.ALv2(
+    s"${startYear.value.get}-${Year.now}",
+    organizationName.value
+  )
+)
+excludeFilter.in(headerResources) := "*.scala"
 
 crossSbtVersions := Seq("0.13.18", "1.2.8")
 releaseCrossBuild := true
@@ -16,13 +32,20 @@ scalacOptions ++= Seq(
   "-unchecked",
   "-deprecation"
 )
-libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.7" % "test"
+libraryDependencies ++= List(
+  "org.sonarsource.scanner.api" % "sonar-scanner-api" % "2.12.0.1661" % Compile,
+  "org.scalatest"               %% "scalatest"        % "3.0.7"       % Test
+)
 scalafmtOnCompile in ThisBuild := true
+cancelable in Global := true
 
 // Scripted
 scriptedLaunchOpts := {
-  scriptedLaunchOpts.value ++
-  Seq("-Xmx1024M", "-Dplugin.version=" + version.value)
+  scriptedLaunchOpts.value ++ Seq(
+    "-Xmx1024M",
+    "-Dplugin.version=" + version.value,
+    "-Dsonar.host.url=http://localhost"
+  )
 }
 scriptedBufferLog := false
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,4 @@
 addSbtPlugin("org.foundweekends" % "sbt-bintray"  % "0.5.5")
 addSbtPlugin("com.github.gseitz" % "sbt-release"  % "1.0.11")
 addSbtPlugin("org.scalameta"     % "sbt-scalafmt" % "2.0.0")
+addSbtPlugin("de.heikoseeberger" % "sbt-header"   % "5.2.0")

--- a/src/main/scala-sbt-0.13/sbtsonar/SbtCompat.scala
+++ b/src/main/scala-sbt-0.13/sbtsonar/SbtCompat.scala
@@ -1,0 +1,10 @@
+package sbtsonar
+
+import scala.sys.process.ProcessBuilder
+
+object SbtCompat {
+  val Using = sbt.Using
+
+  def process(process: ProcessBuilder): Stream[String] =
+    process.lines
+}

--- a/src/main/scala-sbt-0.13/sbtsonar/SbtCompat.scala
+++ b/src/main/scala-sbt-0.13/sbtsonar/SbtCompat.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016-2019 All sbt-sonar contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package sbtsonar
 
 import scala.sys.process.ProcessBuilder

--- a/src/main/scala-sbt-0.13/sbtsonar/SbtCompat.scala
+++ b/src/main/scala-sbt-0.13/sbtsonar/SbtCompat.scala
@@ -19,6 +19,7 @@ package sbtsonar
 import scala.sys.process.ProcessBuilder
 
 object SbtCompat {
+  val Logger = sbt.Logger
   val Using = sbt.Using
 
   def process(process: ProcessBuilder): Stream[String] =

--- a/src/main/scala-sbt-1.0/sbtsonar/SbtCompat.scala
+++ b/src/main/scala-sbt-1.0/sbtsonar/SbtCompat.scala
@@ -16,15 +16,11 @@
 
 package sbtsonar
 
-import java.io.File
-import java.nio.file.Files
+import scala.sys.process.ProcessBuilder
 
-import sbt.IO
+object SbtCompat {
+  val Using = sbt.io.Using
 
-trait WithFile {
-  def withFile(test: File => Any) {
-    val file = Files.createTempFile("sonar-project", ".properties").toFile
-    try test(file)
-    finally IO.delete(file)
-  }
+  def process(process: ProcessBuilder): Stream[String] =
+    process.lineStream
 }

--- a/src/main/scala-sbt-1.0/sbtsonar/SbtCompat.scala
+++ b/src/main/scala-sbt-1.0/sbtsonar/SbtCompat.scala
@@ -19,6 +19,7 @@ package sbtsonar
 import scala.sys.process.ProcessBuilder
 
 object SbtCompat {
+  val Logger = sbt.util.Logger
   val Using = sbt.io.Using
 
   def process(process: ProcessBuilder): Stream[String] =

--- a/src/main/scala/sbtsonar/SonarPlugin.scala
+++ b/src/main/scala/sbtsonar/SonarPlugin.scala
@@ -1,15 +1,33 @@
+/*
+ * Copyright 2016-2019 All sbt-sonar contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package sbtsonar
 
 import java.nio.file.Paths
+import java.util.{Properties => JavaProperties}
 
+import org.sonarsource.scanner.api.EmbeddedScanner
 import sbt.Keys._
 import sbt._
 
+import scala.collection.JavaConverters._
 import scala.sys.process.Process
 import scala.util.Properties
 
 object SonarPlugin extends AutoPlugin {
-
   private val SonarProjectVersionKey = "sonar.projectVersion"
   private val SonarExternalConfigFileName = "sonar-project.properties"
   private val ScoverageReport = "scoverage-report/scoverage.xml"
@@ -18,6 +36,9 @@ object SonarPlugin extends AutoPlugin {
   object autoImport {
     val sonarUseExternalConfig: SettingKey[Boolean] = settingKey(
       "Whether to use an external sonar-project.properties file instead of the properties defined in the sonarProperties Map."
+    )
+    val sonarUseSonarScannerCli: SettingKey[Boolean] = settingKey(
+      "Whether to use a standalone sonar-scanner CLI instead of the embedded sonar-scanner API."
     )
     val sonarProperties: SettingKey[Map[String, String]] = settingKey(
       "SonarScanner configuration properties."
@@ -33,48 +54,45 @@ object SonarPlugin extends AutoPlugin {
 
   override def projectSettings = Seq(
     sonarUseExternalConfig := false,
+    sonarUseSonarScannerCli := false,
     sonarProperties := (
-      Seq(
-        "sonar.projectName" -> name.value,
-        "sonar.projectKey" -> normalizedName.value,
-        "sonar.sourceEncoding" -> "UTF-8",
-        "sonar.scala.version" -> scalaVersion.value
-      ) ++
-      // Base sources directory.
-      sourcesDir(baseDirectory.value, (scalaSource in Compile).value) ++
+        Seq(
+          "sonar.projectName" -> name.value,
+          "sonar.projectKey" -> normalizedName.value,
+          "sonar.sourceEncoding" -> "UTF-8",
+          "sonar.scala.version" -> scalaVersion.value
+        ) ++
+        // Base sources directory.
+        sourcesDir(baseDirectory.value, (scalaSource in Compile).value) ++
 
-      // Base tests directory.
-      testsDir(baseDirectory.value, (scalaSource in Test).value) ++
+        // Base tests directory.
+        testsDir(baseDirectory.value, (scalaSource in Test).value) ++
 
-      // Scoverage & Scapegoat report directories.
-      reports(baseDirectory.value, (crossTarget in Compile).value)
-    ).toMap,
+        // Scoverage & Scapegoat report directories.
+        reports(baseDirectory.value, (crossTarget in Compile).value)
+      ).toMap,
     sonarScan := {
-      implicit val logger: Logger = streams.value.log
+      implicit val log: Logger = streams.value.log
 
-      val sonarHome = sys.env
-        .get("SONAR_SCANNER_HOME")
-        .orElse(sys.props.get("sonarScanner.home"))
-        .getOrElse(
-          sys.error(
-            "SONAR_SCANNER_HOME environment variable or sonarScanner.home system property not defined."
-          )
+      // Allow to set sonar properties via system properties
+      // [https://docs.sonarqube.org/display/SONAR/Analysis+Parameters]
+      val mergedSonarProperties: Map[String, String] =
+        sonarProperties.value ++ sys.props.filterKeys(_.startsWith("sonar."))
+
+      if (sonarUseSonarScannerCli.value)
+        useStandaloneScanner(
+          sonarUseExternalConfig.value,
+          baseDirectory.value,
+          version.value,
+          mergedSonarProperties
         )
-
-      // Update the external properties file if the sonarUseExternalConfig is set to true.
-      if (sonarUseExternalConfig.value)
-        updatePropertiesFile(baseDirectory.value, SonarExternalConfigFileName, version.value)
-
-      //Allow to set sonar properties via system properties: [https://docs.sonarqube.org/display/SONAR/Analysis+Parameters]
-      val mergedSonarProperties = sonarProperties.value ++ sys.props.filterKeys(_.startsWith("sonar."))
-
-      val args = sonarScannerArgs(sonarUseExternalConfig.value, mergedSonarProperties, version.value)
-
-      val executablePath = if (Properties.isWin) "bin/sonar-scanner.bat" else "bin/sonar-scanner"
-      val sonarScanner = Paths.get(sonarHome).resolve(executablePath).toAbsolutePath.toString
-
-      // Run sonar-scanner executable.
-      Process(sonarScanner, args).lines.foreach(logInfo)
+      else
+        useEmbeddedScanner(
+          sonarUseExternalConfig.value,
+          baseDirectory.value,
+          version.value,
+          mergedSonarProperties
+        )
     }
   )
 
@@ -97,7 +115,7 @@ object SonarPlugin extends AutoPlugin {
 
   private[sbtsonar] def updatePropertiesFile(baseDir: File, fileName: String, version: String): Unit = {
     val sonarPropsFile = new File(baseDir, fileName)
-    val sonarProps = IO.readLines(sonarPropsFile)
+    val sonarProps: List[String] = IO.readLines(sonarPropsFile)
 
     def loop(lines: List[String]): List[String] = {
       lines match {
@@ -111,7 +129,7 @@ object SonarPlugin extends AutoPlugin {
     }
 
     // Update sonar project version.
-    val updatedSonarProps = loop(sonarProps)
+    val updatedSonarProps: List[String] = loop(sonarProps)
     IO.writeLines(sonarPropsFile, updatedSonarProps)
   }
 
@@ -120,14 +138,82 @@ object SonarPlugin extends AutoPlugin {
     sonarProperties: Map[String, String],
     version: String
   ): Seq[String] = {
-    if (sonarUseExternalConfig) Seq()
+    if (sonarUseExternalConfig) Seq.empty
     else {
-      val withVersion = sonarProperties + (SonarProjectVersionKey -> version)
-      withVersion.map {
+      (sonarProperties + (SonarProjectVersionKey -> version)).map {
         case (key, value) => s"-D$key=$value"
       }.toSeq
     }
   }
 
-  private[sbtsonar] def logInfo(msg: String)(implicit logger: Logger): Unit = logger.info(msg)
+  private[sbtsonar] def useStandaloneScanner(
+    sonarUseExternalConfig: Boolean,
+    baseDirectory: File,
+    version: String,
+    mergedSonarProperties: Map[String, String]
+  )(implicit log: Logger): Unit = {
+    val sonarHome: String =
+      sys.env
+        .get("SONAR_SCANNER_HOME")
+        .orElse(sys.props.get("sonarScanner.home"))
+        .getOrElse(
+          sys.error(
+            "SONAR_SCANNER_HOME environment variable or sonarScanner.home system property not defined."
+          )
+        )
+
+    // Update the external properties file if the sonarUseExternalConfig is set to true.
+    if (sonarUseExternalConfig)
+      updatePropertiesFile(baseDirectory, SonarExternalConfigFileName, version)
+
+    val args: Seq[String] =
+      sonarScannerArgs(sonarUseExternalConfig, mergedSonarProperties, version)
+
+    val executablePath: String =
+      if (Properties.isWin) "bin/sonar-scanner.bat"
+      else "bin/sonar-scanner"
+
+    val sonarScanner: String =
+      Paths
+        .get(sonarHome)
+        .resolve(executablePath)
+        .toAbsolutePath
+        .toString
+
+    // Run sonar-scanner executable.
+    SbtCompat
+      .process(Process(sonarScanner, args))
+      .foreach(log.info(_))
+  }
+
+  private[sbtsonar] def useEmbeddedScanner(
+    useExternalConfig: Boolean,
+    baseDirectory: File,
+    version: String,
+    mergedSonarProperties: Map[String, String]
+  )(implicit log: Logger): Unit = {
+    val props: Map[String, String] =
+      if (useExternalConfig) {
+        val sonarPropsFile = new File(baseDirectory, SonarExternalConfigFileName)
+        val properties = SbtCompat.Using.fileInputStream(sonarPropsFile) { stream =>
+          val props = new JavaProperties
+          props.load(stream)
+          props.asScala.toMap
+        }
+        properties + (SonarProjectVersionKey -> version)
+      } else mergedSonarProperties
+
+    val embeddedScanner =
+      EmbeddedScanner
+        .create(
+          "sbt-sonar",
+          getClass.getPackage.getImplementationVersion,
+          SonarSbtLogOutput(props)
+        )
+        .addGlobalProperties(props.asJava)
+
+    embeddedScanner.start()
+    log.info("SonarQube server: " + embeddedScanner.serverVersion)
+    embeddedScanner.execute(props.asJava)
+  }
 }

--- a/src/main/scala/sbtsonar/SonarSbtLogOutput.scala
+++ b/src/main/scala/sbtsonar/SonarSbtLogOutput.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2016-2019 All sbt-sonar contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sbtsonar
+
+import org.sonarsource.scanner.api.LogOutput
+import sbt.{Level, Logger}
+
+object SonarSbtLogOutput {
+  def apply(props: Map[String, String])(implicit logger: Logger): LogOutput =
+    new LogOutput {
+      def log(formattedMessage: java.lang.String, level: LogOutput.Level): Unit =
+        level match {
+          case LogOutput.Level.TRACE | LogOutput.Level.DEBUG =>
+            val verbose: Boolean =
+              props
+                .get("sonar.verbose")
+                .exists(_.toLowerCase == "true")
+            val debugTrace: Boolean =
+              props
+                .get("sonar.log.level")
+                .map(_.toLowerCase)
+                .exists(v => v == "debug" || v == "trace")
+            // Log only if "sonar.verbose" is "true"
+            // or "sonar.log.level" is either "DEBUG" or "TRACE".
+            if (verbose || debugTrace)
+              logger.log(Level.Info, formattedMessage)
+          case LogOutput.Level.ERROR =>
+            logger.log(Level.Error, formattedMessage)
+          case LogOutput.Level.WARN =>
+            logger.log(Level.Warn, formattedMessage)
+          case LogOutput.Level.INFO =>
+            logger.log(Level.Info, formattedMessage)
+        }
+    }
+}

--- a/src/test/scala/sbtsonar/SonarPluginTest.scala
+++ b/src/test/scala/sbtsonar/SonarPluginTest.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016-2019 All sbt-sonar contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package sbtsonar
 
 import java.io.File

--- a/src/test/scala/sbtsonar/SonarPluginTest.scala
+++ b/src/test/scala/sbtsonar/SonarPluginTest.scala
@@ -25,7 +25,7 @@ import org.scalatest.{FlatSpec, Matchers}
 import org.scalatestplus.mockito.MockitoSugar
 import org.sonarsource.scanner.api.EmbeddedScanner
 import sbt.IO
-import sbt.util.Logger
+import SbtCompat.Logger
 
 import scala.collection.JavaConverters._
 import scala.util.Properties

--- a/src/test/scala/sbtsonar/SonarPluginTest.scala
+++ b/src/test/scala/sbtsonar/SonarPluginTest.scala
@@ -19,8 +19,10 @@ package sbtsonar
 import java.io.File
 import java.nio.file.Paths
 
-import org.mockito.{ArgumentMatchersSugar, IdiomaticMockito}
-import org.scalatest._
+import org.mockito.ArgumentMatchers._
+import org.mockito.Mockito._
+import org.scalatest.{FlatSpec, Matchers}
+import org.scalatestplus.mockito.MockitoSugar
 import org.sonarsource.scanner.api.EmbeddedScanner
 import sbt.IO
 import sbt.util.Logger
@@ -28,12 +30,7 @@ import sbt.util.Logger
 import scala.collection.JavaConverters._
 import scala.util.Properties
 
-class SonarPluginTest
-    extends FlatSpec
-    with Matchers
-    with IdiomaticMockito
-    with ArgumentMatchersSugar
-    with WithFile {
+class SonarPluginTest extends FlatSpec with Matchers with MockitoSugar with WithFile {
 
   val sonarPropertiesFileContent =
     """# Root project information
@@ -145,7 +142,7 @@ class SonarPluginTest
   "useEmbeddedScanner" should "start the analysis using the embedded scanner" in {
     implicit val log = Logger.Null
     val embeddedScanner = mock[EmbeddedScanner]
-    embeddedScanner.addGlobalProperties(*) shouldReturn embeddedScanner
+    when(embeddedScanner.addGlobalProperties(any())).thenReturn(embeddedScanner)
 
     SonarPlugin.useEmbeddedScanner(
       useExternalConfig = false,
@@ -157,9 +154,9 @@ class SonarPluginTest
     )
 
     val properties = Map("sonar.property1" -> "value1", "sonar.property2" -> "value2")
-    embeddedScanner.addGlobalProperties(properties.asJava) was called
-    embeddedScanner.start was called
-    embeddedScanner.execute(properties.asJava) was called
+    verify(embeddedScanner).addGlobalProperties(properties.asJava)
+    verify(embeddedScanner).start
+    verify(embeddedScanner).execute(properties.asJava)
   }
 
   "useEmbeddedScanner" should "respect properties from an external file" in withFile { file =>
@@ -167,7 +164,7 @@ class SonarPluginTest
 
     implicit val log = Logger.Null
     val embeddedScanner = mock[EmbeddedScanner]
-    embeddedScanner.addGlobalProperties(*) shouldReturn embeddedScanner
+    when(embeddedScanner.addGlobalProperties(any())).thenReturn(embeddedScanner)
 
     SonarPlugin.useEmbeddedScanner(
       useExternalConfig = true,
@@ -188,8 +185,8 @@ class SonarPluginTest
       "sonar.projectVersion" -> "1.2.3",
       "sonar.property2" -> "value2"
     )
-    embeddedScanner.addGlobalProperties(properties.asJava) was called
-    embeddedScanner.start was called
-    embeddedScanner.execute(properties.asJava) was called
+    verify(embeddedScanner).addGlobalProperties(properties.asJava)
+    verify(embeddedScanner).start
+    verify(embeddedScanner).execute(properties.asJava)
   }
 }

--- a/src/test/scala/sbtsonar/SonarPluginTest.scala
+++ b/src/test/scala/sbtsonar/SonarPluginTest.scala
@@ -19,12 +19,38 @@ package sbtsonar
 import java.io.File
 import java.nio.file.Paths
 
+import org.mockito.{ArgumentMatchersSugar, IdiomaticMockito}
 import org.scalatest._
+import org.sonarsource.scanner.api.EmbeddedScanner
 import sbt.IO
+import sbt.util.Logger
 
+import scala.collection.JavaConverters._
 import scala.util.Properties
 
-class SonarPluginTest extends FlatSpec with Matchers with WithFile {
+class SonarPluginTest
+    extends FlatSpec
+    with Matchers
+    with IdiomaticMockito
+    with ArgumentMatchersSugar
+    with WithFile {
+
+  val sonarPropertiesFileContent =
+    """# Root project information
+      |sonar.projectKey=org.mycompany.myproject
+      |sonar.projectName=My Project
+      |sonar.projectVersion=1.0
+      |
+      |# Some properties that will be inherited by the modules
+      |sonar.sources=src
+      |
+      |# List of the module identifiers
+      |sonar.modules=module1,module2
+      |
+      |# Properties can obviously be overriden for
+      |# each module - just prefix them with the module ID
+      |module1.sonar.projectName=Module 1
+      |module2.sonar.projectName=Module 2""".stripMargin
 
   "sourcesDir" should "resolve correctly the relative path" in {
     SonarPlugin.sourcesDir(new File("."), new File("./a/b")) shouldBe
@@ -46,23 +72,6 @@ class SonarPluginTest extends FlatSpec with Matchers with WithFile {
 
   "updatePropertiesFile" should
   "update the sonar properties file with the current project version" in withFile { file =>
-    val content =
-      """# Root project information
-        |sonar.projectKey=org.mycompany.myproject
-        |sonar.projectName=My Project
-        |sonar.projectVersion=1.0
-        |
-        |# Some properties that will be inherited by the modules
-        |sonar.sources=src
-        |
-        |# List of the module identifiers
-        |sonar.modules=module1,module2
-        |
-        |# Properties can obviously be overriden for
-        |# each module - just prefix them with the module ID
-        |module1.sonar.projectName=Module 1
-        |module2.sonar.projectName=Module 2""".stripMargin
-
     val expectedContent =
       """# Root project information
         |sonar.projectKey=org.mycompany.myproject
@@ -80,7 +89,7 @@ class SonarPluginTest extends FlatSpec with Matchers with WithFile {
         |module1.sonar.projectName=Module 1
         |module2.sonar.projectName=Module 2""".stripMargin
 
-    IO.writeLines(file, content.split(Properties.lineSeparator).toSeq)
+    IO.writeLines(file, sonarPropertiesFileContent.split(Properties.lineSeparator).toSeq)
     SonarPlugin.updatePropertiesFile(file.getParentFile, file.getName, "123.456.789")
 
     IO.readLines(file) shouldBe expectedContent.split("\\r?\\n").toList
@@ -89,12 +98,98 @@ class SonarPluginTest extends FlatSpec with Matchers with WithFile {
   "sonarScannerArgs" should
   "convert a map with sonar config properties into a sequence of java env properties " in {
     val sonarProperties = Map("a" -> "b", "c.d" -> "e.f")
-    val result = SonarPlugin.sonarScannerArgs(
+    val systemProperties = Map("sonar.host.url" -> "http://localhost", "sonar.verbose" -> "true")
+
+    val noExternalConfig = SonarPlugin.sonarScannerArgs(
       sonarUseExternalConfig = false,
       sonarProperties = sonarProperties,
+      systemProperties = systemProperties,
       version = "987.654.321"
     )
-    val expected = Seq("-Da=b", "-Dc.d=e.f", "-Dsonar.projectVersion=987.654.321")
-    result shouldBe expected
+    noExternalConfig should contain theSameElementsAs Seq(
+      "-Da=b",
+      "-Dc.d=e.f",
+      "-Dsonar.projectVersion=987.654.321",
+      "-Dsonar.host.url=http://localhost",
+      "-Dsonar.verbose=true"
+    )
+
+    val withExternalConfig = SonarPlugin.sonarScannerArgs(
+      sonarUseExternalConfig = true,
+      sonarProperties = sonarProperties,
+      systemProperties = systemProperties,
+      version = "987.654.321"
+    )
+    withExternalConfig should contain theSameElementsAs Seq(
+      "-Dsonar.host.url=http://localhost",
+      "-Dsonar.verbose=true"
+    )
+  }
+
+  "propertiesFromFile" should "read sonar properties from a file" in withFile { file =>
+    IO.writeLines(file, sonarPropertiesFileContent.split(Properties.lineSeparator).toSeq)
+
+    val expected = Map(
+      "sonar.projectKey" -> "org.mycompany.myproject",
+      "sonar.projectName" -> "My Project",
+      "sonar.projectVersion" -> "1.0",
+      "sonar.sources" -> "src",
+      "sonar.modules" -> "module1,module2",
+      "module1.sonar.projectName" -> "Module 1",
+      "module2.sonar.projectName" -> "Module 2"
+    )
+
+    SonarPlugin.propertiesFromFile(file) should contain theSameElementsAs expected
+  }
+
+  "useEmbeddedScanner" should "start the analysis using the embedded scanner" in {
+    implicit val log = Logger.Null
+    val embeddedScanner = mock[EmbeddedScanner]
+    embeddedScanner.addGlobalProperties(*) shouldReturn embeddedScanner
+
+    SonarPlugin.useEmbeddedScanner(
+      useExternalConfig = false,
+      propertiesFile = new File("."),
+      version = "1.2.3",
+      sonarProperties = Map("sonar.property1" -> "value1"),
+      systemProperties = Map("sonar.property2" -> "value2"),
+      embeddedScanner
+    )
+
+    val properties = Map("sonar.property1" -> "value1", "sonar.property2" -> "value2")
+    embeddedScanner.addGlobalProperties(properties.asJava) was called
+    embeddedScanner.start was called
+    embeddedScanner.execute(properties.asJava) was called
+  }
+
+  "useEmbeddedScanner" should "respect properties from an external file" in withFile { file =>
+    IO.writeLines(file, sonarPropertiesFileContent.split(Properties.lineSeparator).toSeq)
+
+    implicit val log = Logger.Null
+    val embeddedScanner = mock[EmbeddedScanner]
+    embeddedScanner.addGlobalProperties(*) shouldReturn embeddedScanner
+
+    SonarPlugin.useEmbeddedScanner(
+      useExternalConfig = true,
+      propertiesFile = file,
+      version = "1.2.3",
+      sonarProperties = Map("sonar.property1" -> "value1"),
+      systemProperties = Map("sonar.property2" -> "value2"),
+      embeddedScanner
+    )
+
+    val properties = Map(
+      "sonar.projectKey" -> "org.mycompany.myproject",
+      "sonar.projectName" -> "My Project",
+      "sonar.sources" -> "src",
+      "sonar.modules" -> "module1,module2",
+      "module1.sonar.projectName" -> "Module 1",
+      "module2.sonar.projectName" -> "Module 2",
+      "sonar.projectVersion" -> "1.2.3",
+      "sonar.property2" -> "value2"
+    )
+    embeddedScanner.addGlobalProperties(properties.asJava) was called
+    embeddedScanner.start was called
+    embeddedScanner.execute(properties.asJava) was called
   }
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.8.0-SNAPSHOT"
+version in ThisBuild := "2.0.0-SNAPSHOT"


### PR DESCRIPTION
This PR introduces an embedded sonar-scanner by interfacing with the [sonar-scanner-api](https://github.com/SonarSource/sonar-scanner-api). This new "mode" no longer requires having the sonar-scanner cli executable installed. The `SONAR_SCANNER_HOME` environment variable or the `sonarScanner.home` is also no longer required.

It adds an additional setting `sonarUseSonarScannerCli`, which allows users to fall back to using the standalone sonar-scanner cli in case of any issues.

Closes #19.