### PR TITLE
Fix module naming typo in `multi-module` and `multi-module-not-on-root-with-correct-config` tests.

### DIFF
--- a/src/sbt-test/sbt-sonar/multi-module-not-on-root-with-correct-config/build.sbt
+++ b/src/sbt-test/sbt-sonar/multi-module-not-on-root-with-correct-config/build.sbt
@@ -20,11 +20,11 @@ lazy val sonarSettings = Seq(
 
 lazy val module1 = (project in file("test-1/module1"))
   .settings(baseSettings)
-  .settings(name := "module2nirwcc")
+  .settings(name := "module1nirwcc")
 
 lazy val module2 = (project in file("test-2/module2"))
   .settings(baseSettings)
-  .settings(name := "module1nirwcc")
+  .settings(name := "module2nirwcc")
 
 lazy val multiModule = (project in file("."))
   .aggregate(module1, module2)

--- a/src/sbt-test/sbt-sonar/multi-module/build.sbt
+++ b/src/sbt-test/sbt-sonar/multi-module/build.sbt
@@ -18,11 +18,9 @@ lazy val sonarSettings = Seq(
 
 lazy val module1 = (project in file("module1"))
   .settings(baseSettings)
-  .settings(name := "module2")
 
 lazy val module2 = (project in file("module2"))
   .settings(baseSettings)
-  .settings(name := "module1")
 
 lazy val multiModule = (project in file("."))
   .aggregate(module1, module2)


### PR DESCRIPTION
The module names were mixed up in a few places in `src/sbt-test/sbt-sonar/`:
- `multi-module`: Removed explicit `name` assignment because it matches the module `val` name, which SBT will automatically assign as the name [as per the documentation](https://www.scala-sbt.org/1.x/docs/Multi-Project.html).
- `multi-module-not-on-root-with-correct-config`: Fixed the names used for the modules.